### PR TITLE
removed apostrophe in favor of more grammatically appropriate dash

### DIFF
--- a/.guides/content/Floating-balloons--94e4.md
+++ b/.guides/content/Floating-balloons--94e4.md
@@ -1,6 +1,6 @@
-In the left hand pane, you will find a little playground for floats. What better than balloons to play with `float`'ing elements ?
+In the left hand pane, you will find a little playground for floats. What better than balloons to play with `float`-ing elements ?
 
-The playground is composed of 3 main parts: 
+The playground is composed of 3 main parts:
 
 1. The big balloons, numbered 1 to 5 are all block-level elements.
 1. The multiple paragraphs of text underneath are used to show the interactions of floating elements with text.


### PR DESCRIPTION
The apostrophe in an English term signifies possession or contraction.  Neither is the case here, instead we should use either `float`ing or `float`-ing.  The former is more correct (as the word is floating, and we're playing with typography), but the latter is more commonly applied.